### PR TITLE
Trim down liberty features for coffeeshop service

### DIFF
--- a/coffeeshop-service/pom.xml
+++ b/coffeeshop-service/pom.xml
@@ -31,6 +31,12 @@
         </dependency> 
         <dependency>
             <groupId>io.openliberty.features</groupId>
+            <artifactId>jsonb-1.0</artifactId>
+            <version>19.0.0.11</version>
+            <type>esa</type>
+          </dependency> 
+        <dependency>
+            <groupId>io.openliberty.features</groupId>
             <artifactId>mpRestClient-1.3</artifactId>
             <version>19.0.0.11</version>
             <type>esa</type>

--- a/coffeeshop-service/pom.xml
+++ b/coffeeshop-service/pom.xml
@@ -13,28 +13,28 @@
     <!-- Open Liberty Features -->
     <dependency>
       <groupId>io.openliberty.features</groupId>
-      <artifactId>microProfile-3.0</artifactId>
-      <version>19.0.0.11</version>
-      <type>esa</type>
-    </dependency>
-    <dependency>
-      <groupId>io.openliberty.features</groupId>
       <artifactId>mpReactiveMessaging-1.0</artifactId>
       <version>19.0.0.11</version>
       <type>esa</type>
     </dependency>
     <dependency>
-      <groupId>io.openliberty.features</groupId>
-      <artifactId>mpReactiveStreams-1.0</artifactId>
-      <version>19.0.0.11</version>
-      <type>esa</type>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.microprofile.config</groupId>
-      <artifactId>microprofile-config-api</artifactId>
-      <version>1.3</version>
-      <scope>provided</scope>
-    </dependency>
+        <groupId>io.openliberty.features</groupId>
+        <artifactId>mpHealth-2.0</artifactId>
+        <version>19.0.0.11</version>
+        <type>esa</type>
+      </dependency>
+      <dependency>
+          <groupId>io.openliberty.features</groupId>
+          <artifactId>jaxrs-2.1</artifactId>
+          <version>19.0.0.11</version>
+          <type>esa</type>
+        </dependency> 
+        <dependency>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>mpRestClient-1.3</artifactId>
+            <version>19.0.0.11</version>
+            <type>esa</type>
+          </dependency> 
     <dependency>
       <groupId>org.eclipse.microprofile.reactive.messaging</groupId>
       <artifactId>microprofile-reactive-messaging-api</artifactId>

--- a/coffeeshop-service/src/main/liberty/config/server.xml
+++ b/coffeeshop-service/src/main/liberty/config/server.xml
@@ -2,6 +2,7 @@
 
   <featureManager>
     <feature>jaxrs-2.1</feature>
+    <feature>jsonb-1.0</feature>
     <feature>mpHealth-2.0</feature>
     <feature>mpRestClient-1.3</feature>
     <feature>mpReactiveMessaging-1.0</feature>

--- a/coffeeshop-service/src/main/liberty/config/server.xml
+++ b/coffeeshop-service/src/main/liberty/config/server.xml
@@ -1,9 +1,10 @@
 <server description="Sample Liberty server">
 
   <featureManager>
-    <feature>microProfile-3.0</feature>
+    <feature>jaxrs-2.1</feature>
+    <feature>mpHealth-2.0</feature>
+    <feature>mpRestClient-1.3</feature>
     <feature>mpReactiveMessaging-1.0</feature>
-    <feature>mpReactiveStreams-1.0</feature>
   </featureManager>
 
   <httpEndpoint httpPort="8080" id="defaultHttpEndpoint" host="*" />


### PR DESCRIPTION
I've removed the umbrella microproofile-3.0 feature and included only the bits we actually need. In my unscientific tests on my local minikube environment, this looks to shave about 10s off the startup time. 