### PR TITLE
Tool for placing orders and monitoring event queue

### DIFF
--- a/monitor-consumers.sh
+++ b/monitor-consumers.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+#export JAVA_HOME="/cygdrive/c/Progra~1/AdoptOpenJDK/jdk-8.0.232.09-openj9/"
+#$KAFKA_PATH/../kafka-consumer-groups.sh --bootstrap-server localhost:32100 --describe --group baristas
+
+cmd /C "kafka-consumer-groups.bat --bootstrap-server localhost:32100 --describe  --group baristas"
+
+while true; do
+  sleep 5
+  (cmd /C "kafka-consumer-groups.bat --bootstrap-server localhost:32100 --describe  --group baristas") &
+  #echo $OUTPUT | head -n -5
+  #echo $OUTPUT | tail -n 5 | sort -n
+done

--- a/monitor-pods.sh
+++ b/monitor-pods.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+
+while true; do
+  (kubectl get pods -n coffee ; echo "" ; kubectl get hpa -n coffee ; echo "") &
+  sleep 5
+done

--- a/tool/load.go
+++ b/tool/load.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+func orderCoffee(baseURL string, orders int) {
+	coffeeURL := baseURL + "/messaging"
+
+	for i := 1; i <= orders; i++ {
+		orderName := fmt.Sprintf("Demo-%v", i)
+		orderJSON := fmt.Sprintf("{\"name\": \"%v\", \"product\": \"espresso\"}", orderName)
+		resp, err := http.Post(coffeeURL, "application/json", strings.NewReader(orderJSON))
+		if err != nil {
+			fmt.Printf("Error sending request %v: %v\n", i, err)
+			break
+		}
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			fmt.Printf("Error reading body for %v: %v\n", i, err)
+			break
+		}
+		order := Order{}
+		json.Unmarshal([]byte(body), &order)
+		fmt.Printf("Order %v is: %v\n", i, order)
+	}
+}

--- a/tool/load.go
+++ b/tool/load.go
@@ -6,13 +6,14 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"sync"
 )
 
-func orderCoffee(baseURL string, orders int) {
+func orderCoffee(baseURL string, orders int, name string, wg *sync.WaitGroup) {
 	coffeeURL := baseURL + "/messaging"
 
 	for i := 1; i <= orders; i++ {
-		orderName := fmt.Sprintf("Demo-%v", i)
+		orderName := fmt.Sprintf("%v-%v", name, i)
 		orderJSON := fmt.Sprintf("{\"name\": \"%v\", \"product\": \"espresso\"}", orderName)
 		resp, err := http.Post(coffeeURL, "application/json", strings.NewReader(orderJSON))
 		if err != nil {
@@ -29,4 +30,6 @@ func orderCoffee(baseURL string, orders int) {
 		json.Unmarshal([]byte(body), &order)
 		fmt.Printf("Order %v is: %v\n", i, order)
 	}
+
+	wg.Done()
 }

--- a/tool/main.go
+++ b/tool/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"sync"
 )
 
 // Order is a coffee order placed with the coffeeshop-service
@@ -30,13 +31,20 @@ func main() {
 	baseURL := flag.String("url", "http://localhost:8080", "The base URL of the coffeeshop-service")
 	orders := flag.Int("orders", 5, "Number of orders to place")
 	order := flag.Bool("order", false, "Orders should be placed")
+	name := flag.String("name", "Demo", "Name of person ordering coffee")
 	consume := flag.Bool("monitor", false, "Queue should be monitored")
 	flag.Parse()
 
+	var wg sync.WaitGroup
+
 	if *order {
-		orderCoffee(*baseURL, *orders)
+		wg.Add(1)
+		go orderCoffee(*baseURL, *orders, *name, &wg)
 	}
 	if *consume {
-		consumeCoffee(*baseURL)
+		wg.Add(1)
+		consumeCoffee(*baseURL, &wg)
 	}
+
+	wg.Wait()
 }

--- a/tool/main.go
+++ b/tool/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"flag"
+)
+
+// Order is a coffee order placed with the coffeeshop-service
+type Order struct {
+	Name    string
+	Product string
+	OrderID string
+}
+
+// Beverage is a product produced by a barista
+type Beverage struct {
+	Beverage   string
+	Customer   string
+	OrderID    string
+	PreparedBy string
+}
+
+// Fulfillment is the completion of an order with a beverage
+type Fulfillment struct {
+	Beverage Beverage
+	Order    Order
+	State    string
+}
+
+func main() {
+	baseURL := flag.String("url", "http://localhost:8080", "The base URL of the coffeeshop-service")
+	orders := flag.Int("orders", 5, "Number of orders to place")
+	order := flag.Bool("order", false, "Orders should be placed")
+	consume := flag.Bool("monitor", false, "Queue should be monitored")
+	flag.Parse()
+
+	if *order {
+		orderCoffee(*baseURL, *orders)
+	}
+	if *consume {
+		consumeCoffee(*baseURL)
+	}
+}

--- a/tool/main.go
+++ b/tool/main.go
@@ -43,7 +43,9 @@ func main() {
 	}
 	if *consume {
 		wg.Add(1)
-		consumeCoffee(*baseURL, &wg)
+		go consumeCoffee(*baseURL, &wg)
+		wg.Add(1)
+		go monitorOrders(&wg)
 	}
 
 	wg.Wait()

--- a/tool/monitor.go
+++ b/tool/monitor.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/r3labs/sse"
 )
@@ -13,7 +14,7 @@ var orders map[string][]Order
 // Record of beverages prepared
 var beverages map[string][]Beverage
 
-func consumeCoffee(baseURL string) {
+func consumeCoffee(baseURL string, wg *sync.WaitGroup) {
 	queueURL := baseURL + "/queue"
 
 	orders = make(map[string][]Order)
@@ -21,6 +22,8 @@ func consumeCoffee(baseURL string) {
 
 	client := sse.NewClient(queueURL)
 	client.SubscribeRaw(consumeEvent)
+
+	wg.Done()
 }
 
 func consumeEvent(msg *sse.Event) {

--- a/tool/monitor.go
+++ b/tool/monitor.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/r3labs/sse"
+)
+
+// Record of orders placed
+var orders map[string][]Order
+
+// Record of beverages prepared
+var beverages map[string][]Beverage
+
+func consumeCoffee(baseURL string) {
+	queueURL := baseURL + "/queue"
+
+	orders = make(map[string][]Order)
+	beverages = make(map[string][]Beverage)
+
+	client := sse.NewClient(queueURL)
+	client.SubscribeRaw(consumeEvent)
+}
+
+func consumeEvent(msg *sse.Event) {
+	// All events on the queue should be in the Fulfillment format. They may or
+	// may not contain a Beverage.
+	fulfillment := Fulfillment{}
+	json.Unmarshal(msg.Data, &fulfillment)
+
+	state := fulfillment.State
+	order := fulfillment.Order
+	beverage := fulfillment.Beverage
+
+	switch state {
+	case "IN_QUEUE":
+		fmt.Printf("%v has ordered a %v: orderId=%v\n", order.Name, order.Product, order.OrderID)
+		existingOrder, present := orders[order.OrderID]
+		if !present {
+			orders[order.OrderID] = []Order{order}
+		} else {
+			fmt.Printf("ERROR: duplicate order:\n  - new order: %v\n  - existing order: %v\n", order, existingOrder)
+			orders[order.OrderID] = append(orders[order.OrderID], order)
+			fmt.Printf(" - total requests for this order: %v\n", len(orders[order.OrderID]))
+		}
+	case "READY":
+		barista := beverage.PreparedBy
+		fmt.Printf("Beverage for %v is ready: prepared by %v\n", order.Name, barista)
+		existingBeverage, present := beverages[order.OrderID]
+		if !present {
+			beverages[order.OrderID] = []Beverage{beverage}
+		} else {
+			fmt.Printf("ERROR: duplicate beverage:\n  - new beverage: %v\n  - existing beverage: %v\n", beverage, existingBeverage)
+			beverages[order.OrderID] = append(beverages[order.OrderID], beverage)
+			fmt.Printf(" - total completions for this order: %v\n", len(beverages[order.OrderID]))
+		}
+		// Consistency checks
+		if beverage.Customer != order.Name {
+			fmt.Printf("ERROR: Customer name does not match order: Order name=%v, Beverage customer=%v\n", order.Name, beverage.Customer)
+		}
+		if beverage.OrderID != order.OrderID {
+			fmt.Printf("ERROR: Order IDs do not match: Order=%v, Beverage=%v\n", order.OrderID, beverage.OrderID)
+		}
+	default:
+		fmt.Printf("ERROR: Unknown state: %v", state)
+	}
+}

--- a/tool/orders.go
+++ b/tool/orders.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+var oLock = sync.RWMutex{}
+var bLock = sync.RWMutex{}
+
+// Record of orders placed
+var _orders map[string][]Order = make(map[string][]Order)
+
+// Record of beverages prepared
+var _beverages map[string][]Beverage = make(map[string][]Beverage)
+
+//orders = make(map[string][]Order)
+//beverages = make(map[string][]Beverage)
+
+func getAllOrders() []string {
+	oLock.RLock()
+	defer oLock.RUnlock()
+	keys := make([]string, len(_orders))
+	i := 0
+	for key := range _orders {
+		keys[i] = key
+		i++
+	}
+	return keys
+}
+
+func getOrders(key string) ([]Order, bool) {
+	oLock.RLock()
+	defer oLock.RUnlock()
+	value, present := _orders[key]
+	return value, present
+}
+
+func getOrder(key string) Order {
+	oLock.RLock()
+	defer oLock.RUnlock()
+	value, present := _orders[key]
+	if present {
+		return value[0]
+	}
+	fmt.Printf("Error - cannot look up order '%v', not present\n", key)
+	return Order{}
+}
+
+func numOrders(key string) int {
+	oLock.RLock()
+	defer oLock.RUnlock()
+	return len(_orders[key])
+}
+
+func setOrder(key string, value Order) {
+	oLock.Lock()
+	defer oLock.Unlock()
+	_orders[key] = []Order{value}
+}
+
+func appendOrder(key string, value Order) {
+	oLock.Lock()
+	defer oLock.Unlock()
+	_orders[key] = append(_orders[key], value)
+}
+
+func getBeverages(key string) ([]Beverage, bool) {
+	bLock.RLock()
+	defer bLock.RUnlock()
+	value, present := _beverages[key]
+	return value, present
+}
+
+func numBeverages(key string) int {
+	bLock.RLock()
+	defer bLock.RUnlock()
+	return len(_beverages[key])
+}
+
+func setBeverage(key string, value Beverage) {
+	bLock.Lock()
+	defer bLock.Unlock()
+	_beverages[key] = []Beverage{value}
+}
+
+func appendBeverage(key string, value Beverage) {
+	bLock.Lock()
+	defer bLock.Unlock()
+	_beverages[key] = append(_beverages[key], value)
+}


### PR DESCRIPTION
This adds a simple Go tool for placing a set of orders in bulk, and for monitoring the event stream to keep track of which orders have been processed, and any errors (duplicate processing).

Also adds a couple of simple scripts for monitoring the consumer group and active pods.

- ~TODO: keep track of orders that have not been fulfilled~
  - Tool now shows order status (number of completions) periodically.
- ~TODO: event stream monitoring seems to have stopped working with the latest version of the Liberty coffeeshop-service?~
  - Fixed (https://github.com/r3labs/sse/pull/69)