### PR TITLE
Improve Liberty startup time

### DIFF
--- a/barista-http/Dockerfile
+++ b/barista-http/Dockerfile
@@ -25,7 +25,7 @@ COPY --from=build --chown=1001:0 /project/barista-http/src/main/liberty/config/s
 
 # Start and stop Liberty to create the shared class cache
 # To capture JVM start options, add: -verbose:gc -Xverbosegclog:/tmp/gc.log.%p
-ENV JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Xtune:virtualized"
+ENV JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Xquickstart -Xms64m -Xmn48m"
 RUN /opt/ol/wlp/bin/server start defaultServer && sleep 5 && /opt/ol/wlp/bin/server stop defaultServer && (java -Xshareclasses:name=liberty-%u,nonfatal,cacheDir=/opt/ol/wlp/output/.classCache,printStats || echo "OK")
 
 EXPOSE 8082

--- a/barista-http/Dockerfile
+++ b/barista-http/Dockerfile
@@ -23,6 +23,11 @@ FROM open-liberty
 COPY --from=build --chown=1001:0 /project/barista-http/target/barista-http-1.0-SNAPSHOT.war /opt/ol/wlp/usr/servers/defaultServer/apps
 COPY --from=build --chown=1001:0 /project/barista-http/src/main/liberty/config/server.xml /opt/ol/wlp/usr/servers/defaultServer
 
+# Start and stop Liberty to create the shared class cache
+# To capture JVM start options, add: -verbose:gc -Xverbosegclog:/tmp/gc.log.%p
+ENV JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Xtune:virtualized"
+RUN /opt/ol/wlp/bin/server start defaultServer && sleep 5 && /opt/ol/wlp/bin/server stop defaultServer && (java -Xshareclasses:name=liberty-%u,nonfatal,cacheDir=/opt/ol/wlp/output/.classCache,printStats || echo "OK")
+
 EXPOSE 8082
 
 # We inherit the CMD to start the Liberty server from the open-liberty image

--- a/barista-kafka/Dockerfile
+++ b/barista-kafka/Dockerfile
@@ -26,7 +26,7 @@ COPY barista-kafka/barista-name.sh /tmp
 
 # Start and stop Liberty to create the shared class cache
 # To capture JVM start options, add: -verbose:gc -Xverbosegclog:/tmp/gc.log.%p
-ENV JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Xtune:virtualized"
+ENV JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Xquickstart -Xms64m -Xmn48m"
 RUN /opt/ol/wlp/bin/server start defaultServer && sleep 5 && /opt/ol/wlp/bin/server stop defaultServer && (java -Xshareclasses:name=liberty-%u,nonfatal,cacheDir=/opt/ol/wlp/output/.classCache,printStats || echo "OK")
 
 EXPOSE 8090

--- a/barista-kafka/Dockerfile
+++ b/barista-kafka/Dockerfile
@@ -1,3 +1,6 @@
+ARG scc_dir="/tmp/scc"
+ARG scc_opts="-Xshareclasses:name=coffeeshop,cacheDir=${scc_dir},cacheDirPerm=0777"
+
 FROM adoptopenjdk/maven-openjdk8-openj9 AS build
 
 WORKDIR /project
@@ -17,10 +20,21 @@ RUN mvn -q -f barista-kafka/pom.xml package
 
 ## Create Image
 FROM open-liberty
+ARG scc_opts
 
 COPY --from=build --chown=1001:0 /project/barista-kafka/target/barista-kafka-1.0-SNAPSHOT.war /opt/ol/wlp/usr/servers/defaultServer/apps
 COPY --from=build --chown=1001:0 /project/barista-kafka/src/main/liberty/config/server.xml /opt/ol/wlp/usr/servers/defaultServer
+
+# Copy utility for generating random Barista name
 COPY barista-kafka/barista-name.sh /tmp
+
+# Clear Liberty's default java options (scc) so ours do not conflict
+ENV IBM_JAVA_OPTIONS=
+
+# Start and stop Liberty to create the shared class cache
+#ENV JAVA_TOOL_OPTIONS="${scc_opts} -Xscmx20m -Xtune:virtualized"
+ENV JAVA_TOOL_OPTIONS="${scc_opts}"
+RUN /opt/ol/wlp/bin/server start defaultServer && sleep 5 && /opt/ol/wlp/bin/server stop defaultServer && (java ${scc_opts},printStats || echo "OK")
 
 EXPOSE 8090
 

--- a/barista-kafka/Dockerfile
+++ b/barista-kafka/Dockerfile
@@ -1,6 +1,3 @@
-ARG scc_dir="/tmp/scc"
-ARG scc_opts="-Xshareclasses:name=coffeeshop,cacheDir=${scc_dir},cacheDirPerm=0777"
-
 FROM adoptopenjdk/maven-openjdk8-openj9 AS build
 
 WORKDIR /project
@@ -20,7 +17,6 @@ RUN mvn -q -f barista-kafka/pom.xml package
 
 ## Create Image
 FROM open-liberty
-ARG scc_opts
 
 COPY --from=build --chown=1001:0 /project/barista-kafka/target/barista-kafka-1.0-SNAPSHOT.war /opt/ol/wlp/usr/servers/defaultServer/apps
 COPY --from=build --chown=1001:0 /project/barista-kafka/src/main/liberty/config/server.xml /opt/ol/wlp/usr/servers/defaultServer
@@ -28,13 +24,10 @@ COPY --from=build --chown=1001:0 /project/barista-kafka/src/main/liberty/config/
 # Copy utility for generating random Barista name
 COPY barista-kafka/barista-name.sh /tmp
 
-# Clear Liberty's default java options (scc) so ours do not conflict
-ENV IBM_JAVA_OPTIONS=
-
 # Start and stop Liberty to create the shared class cache
-#ENV JAVA_TOOL_OPTIONS="${scc_opts} -Xscmx20m -Xtune:virtualized"
-ENV JAVA_TOOL_OPTIONS="${scc_opts}"
-RUN /opt/ol/wlp/bin/server start defaultServer && sleep 5 && /opt/ol/wlp/bin/server stop defaultServer && (java ${scc_opts},printStats || echo "OK")
+# To capture JVM start options, add: -verbose:gc -Xverbosegclog:/tmp/gc.log.%p
+ENV JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Xtune:virtualized"
+RUN /opt/ol/wlp/bin/server start defaultServer && sleep 5 && /opt/ol/wlp/bin/server stop defaultServer && (java -Xshareclasses:name=liberty-%u,nonfatal,cacheDir=/opt/ol/wlp/output/.classCache,printStats || echo "OK")
 
 EXPOSE 8090
 

--- a/coffeeshop-service/Dockerfile
+++ b/coffeeshop-service/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=build --chown=1001:0 /project/coffeeshop-service/src/main/liberty/co
 
 # Start and stop Liberty to create the shared class cache
 # To capture JVM start options, add: -verbose:gc -Xverbosegclog:/tmp/gc.log.%p
-ENV JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Xtune:virtualized"
+ENV JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Xquickstart -Xms64m -Xmn48m"
 RUN /opt/ol/wlp/bin/server start defaultServer && sleep 5 && /opt/ol/wlp/bin/server stop defaultServer && (java -Xshareclasses:name=liberty-%u,nonfatal,cacheDir=/opt/ol/wlp/output/.classCache,printStats || echo "OK")
 
 EXPOSE 8080

--- a/coffeeshop-service/Dockerfile
+++ b/coffeeshop-service/Dockerfile
@@ -21,6 +21,11 @@ FROM open-liberty
 COPY --from=build --chown=1001:0 /project/coffeeshop-service/target/coffeeshop-service-1.0-SNAPSHOT.war /opt/ol/wlp/usr/servers/defaultServer/apps
 COPY --from=build --chown=1001:0 /project/coffeeshop-service/src/main/liberty/config/server.xml /opt/ol/wlp/usr/servers/defaultServer
 
+# Start and stop Liberty to create the shared class cache
+# To capture JVM start options, add: -verbose:gc -Xverbosegclog:/tmp/gc.log.%p
+ENV JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Xtune:virtualized"
+RUN /opt/ol/wlp/bin/server start defaultServer && sleep 5 && /opt/ol/wlp/bin/server stop defaultServer && (java -Xshareclasses:name=liberty-%u,nonfatal,cacheDir=/opt/ol/wlp/output/.classCache,printStats || echo "OK")
+
 EXPOSE 8080
 
 # We inherit the CMD to start Liberty from the open-liberty image


### PR DESCRIPTION
- Warm the openj9 shared class cache while building the image, so that the containers start up in a 'warm' state,
- Use `-Xquickstart` to tune for startup time instead of throughput (in my experiments, this seemed to be marginally quicker than `-Xtune:virtualized`),
- Set the initial Java heap and nursery size to a slightly larger value, to remove unnecessary GC effort during startup.

This reduces Liberty startup time significantly in the Kubernetes environment.  When starting 5 concurrent barista-kafka pods, average startup time reduces from ~20 seconds to ~4 seconds (local k8s cluster on my laptop).