### PR TITLE
Install Keda into own namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,11 @@ script:
     # Install Strimzi custom resource, and wait for cluster creation
   - kubectl apply -f kafka-strimzi.yml -n kafka
   - kubectl wait --for=condition=Ready kafkas/my-cluster -n kafka --timeout 300s
-    # Prepare Helm dependencies (Keda)
-  - helm dependency update ./coffeeshop-chart
+    # Create namespace for Keda
+  - kubectl create ns keda
+    # Install Keda Helm chart
+  - helm repo add kedacore https://kedacore.github.io/charts
+  - helm install keda kedacore/keda -n keda --wait --timeout 300s
     # Deploy to local cluster via helm, into coffee namespace.
   - kubectl create ns coffee
   - helm install coffee-v1 ./coffeeshop-chart -n coffee --wait --timeout 300s --set baristaKafka.image.repository=registry:5000/barista-kafka --set baristaHttp.image.repository=registry:5000/barista-http --set coffeeshopService.image.repository=registry:5000/coffeeshop-service

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can install everything using Helm by running the supplied `install.sh` (or `
 
 To install manually, the steps are:
 
-1. Install Strimzi
+1. Install the Strimzi operator
 ```bash
 kubectl create ns strimzi
 kubectl create ns kafka
@@ -41,10 +41,15 @@ helm install strimzi strimzi/strimzi-kafka-operator -n strimzi --set watchNamesp
 kubectl apply -f kafka-strimzi.yml -n kafka
 kubectl wait --for=condition=Ready kafkas/my-cluster -n kafka --timeout 180s
 ```
+1. Install the Keda operator
+```bash
+kubectl create ns keda
+helm repo add kedacore https://kedacore.github.io/charts
+helm install keda kedacore/keda -n keda --wait --timeout 300s
+```
 1. Install coffeeshop chart
 ```bash
 kubectl create ns coffee
-helm dependency update ./coffeeshop-chart
 helm install coffee-v1 ./coffeeshop-chart -n coffee --wait --timeout 300s
 ```
 
@@ -52,6 +57,10 @@ Once installed, you can access the service either using the NodePort, or you can
 ```bash
 kubectl port-forward service/coffee-v1-coffeeshop-service 8080:8080 -n coffee
 ```
+
+### Obtaining the node IP and port
+
+If installing to a remote cluster, the `postinstall.sh` (and `postinstall.bat`) script will query Kubernetes to obtain the external IP and NodePort and provide you with the corresponding coffeeshop URL.  This is run at the end of the provided install script.
 
 ### Validating
 
@@ -81,6 +90,9 @@ If you want to clear out everything that was created by the chart, either use th
 ```bash
 helm uninstall coffee-v1 -n coffee
 kubectl delete ns coffee
+
+helm uninstall keda -n keda
+kubectl delete ns keda
 
 kubectl delete -f kafka-strimzi.yml -n kafka
 kubectl delete ns kafka

--- a/coffeeshop-chart/Chart.lock
+++ b/coffeeshop-chart/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: keda
-  repository: https://kedacore.github.io/charts/
-  version: 1.0.0
-digest: sha256:1ed6bc9c48aac348aeb237f491b9cac716a7ad62b048dc953f15c83bc88fa06d
-generated: "2019-11-25T16:14:31.9815053Z"

--- a/coffeeshop-chart/Chart.yaml
+++ b/coffeeshop-chart/Chart.yaml
@@ -2,15 +2,18 @@ apiVersion: v2
 name: coffeeshop-chart
 description: A Helm chart for Kubernetes
 
-dependencies:
+#dependencies:
 #  - name: nginx-ingress
 #    version: 1.25.0
 #    repository: https://kubernetes-charts.storage.googleapis.com/
-  - name: keda
-    version: 1.0.0
-    repository: https://kedacore.github.io/charts/
-# Helm 3 does not install the CRDs early enough for us to reference.
-# Strimzi chart must be installed manually first.
+
+# Keda chart must be installed manually first (into its own namespace).
+#  - name: keda
+#    version: 1.0.0
+#    repository: https://kedacore.github.io/charts/
+
+# Strimzi chart must be installed manually first (into its own namespace).
+# The Kafka cluster should then be created (into Values.kafka.namespace, which defaults to 'kafka').
 #  - name: strimzi-kafka-operator
 #    version: 0.14.0
 #    repository: https://strimzi.io/charts/

--- a/install.bat
+++ b/install.bat
@@ -10,20 +10,20 @@ helm install strimzi strimzi/strimzi-kafka-operator -n strimzi --set watchNamesp
 kubectl apply -f kafka-strimzi.yml -n kafka
 kubectl wait --for=condition=Ready kafkas/my-cluster -n kafka --timeout 180s
 
-:: Install coffeeshop-demo into coffee namespace. Chart defaults to
-:: installing kafka cluster into kafka namespace.
+:: Create namespace for Keda
+kubectl create ns keda
+
+:: Install Keda Helm chart
+helm repo add kedacore https://kedacore.github.io/charts
+helm install keda kedacore/keda -n keda --wait --timeout 300s
+
+:: Install coffeeshop-demo into coffee namespace. Requires that Kafka cluster
+:: is already created. Contains custom resources:
+:: - Strimzi: CRs for orders and queue topics (installed into kafka ns)
+:: - Keda: ScaledObject for barista-kafka service (installed into coffee ns)
 kubectl create ns coffee
-helm dependency update ./coffeeshop-chart
 helm install coffee-v1 ./coffeeshop-chart -n coffee --wait --timeout 300s
 :: To pull images from a remote repo, override the image repository.
 :: Eg: --set baristaKafka.image.repository=registry:5000/barista-kafka --set baristaHttp.image.repository=registry:5000/barista-http --set coffeeshopService.image.repository=registry:5000/coffeeshop-service
 
-:: Display overall system state for kafka and coffee namespaces
-kubectl get all -n kafka
-kubectl get all -n coffee
-
-:: Get NodePort for coffeeshop-service
-FOR /F "tokens=* USEBACKQ" %%F IN (`kubectl get -o jsonpath^="{.spec.ports[0].nodePort}" services coffee-v1-coffeeshop-service --namespace coffee`) DO (
-    SET NODE_PORT=%%F
-)
-echo "Order coffees at http://localhost:%NODE_PORT%/"
+call postinstall.bat

--- a/install.sh
+++ b/install.sh
@@ -12,18 +12,20 @@ helm install strimzi strimzi/strimzi-kafka-operator -n strimzi --set watchNamesp
 kubectl apply -f kafka-strimzi.yml -n kafka
 kubectl wait --for=condition=Ready kafkas/my-cluster -n kafka --timeout 180s
 
-# Install coffeeshop-demo into coffee namespace. Chart defaults to
-# installing kafka cluster into kafka namespace.
+# Create namespace for Keda
+kubectl create ns keda
+
+# Install Keda Helm chart
+helm repo add kedacore https://kedacore.github.io/charts
+helm install keda kedacore/keda -n keda --wait --timeout 300s
+
+# Install coffeeshop-demo into coffee namespace. Requires that Kafka cluster
+# is already created. Contains custom resources:
+# - Strimzi: CRs for orders and queue topics (installed into kafka ns)
+# - Keda: ScaledObject for barista-kafka service (installed into coffee ns)
 kubectl create ns coffee
-helm dependency update ./coffeeshop-chart
 helm install coffee-v1 ./coffeeshop-chart -n coffee --wait --timeout 300s
 # To pull images from a remote repo, override the image repository.
 # Eg: --set baristaKafka.image.repository=registry:5000/barista-kafka --set baristaHttp.image.repository=registry:5000/barista-http --set coffeeshopService.image.repository=registry:5000/coffeeshop-service
 
-# Display overall system state for kafka and coffee namespaces
-kubectl get all -n kafka
-kubectl get all -n coffee
-
-# Get NodePort for coffeeshop-service
-export NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services coffee-v1-coffeeshop-service --namespace coffee)
-echo "Order coffees at http://localhost:${NODE_PORT}/"
+./postinstall.sh

--- a/postinstall.bat
+++ b/postinstall.bat
@@ -1,12 +1,22 @@
+@ECHO OFF
+
 :: Display overall system state for kafka and coffee namespaces
-kubectl get all -n kafka
-kubectl get all -n coffee
+kubectl get services -n kafka
+kubectl get services -n coffee
 
 :: Get NodePort for coffeeshop-service
+SET NODE_PORT=
 FOR /F "tokens=* USEBACKQ" %%F IN (`kubectl get -o jsonpath^="{.spec.ports[0].nodePort}" services coffee-v1-coffeeshop-service --namespace coffee`) DO (
     SET NODE_PORT=%%F
 )
+:: Get external IP address for node (assumes single node).
+SET NODE_IP=
 FOR /F "tokens=* USEBACKQ" %%F IN (`kubectl get nodes -o jsonpath^="{ $.items[*].status.addresses[?(@.type=='ExternalIP')].address }"`) DO (
     SET NODE_IP=%%F
 )
-echo "Order coffees at http://%NODE_IP%:%NODE_PORT%/"
+:: If there is no ExternalIP, assume localhost
+IF "%NODE_IP%"=="" (
+    SET NODE_IP=localhost
+)
+echo.
+echo Order coffees at http://%NODE_IP%:%NODE_PORT%/

--- a/postinstall.bat
+++ b/postinstall.bat
@@ -1,0 +1,12 @@
+:: Display overall system state for kafka and coffee namespaces
+kubectl get all -n kafka
+kubectl get all -n coffee
+
+:: Get NodePort for coffeeshop-service
+FOR /F "tokens=* USEBACKQ" %%F IN (`kubectl get -o jsonpath^="{.spec.ports[0].nodePort}" services coffee-v1-coffeeshop-service --namespace coffee`) DO (
+    SET NODE_PORT=%%F
+)
+FOR /F "tokens=* USEBACKQ" %%F IN (`kubectl get nodes -o jsonpath^="{ $.items[*].status.addresses[?(@.type=='ExternalIP')].address }"`) DO (
+    SET NODE_IP=%%F
+)
+echo "Order coffees at http://%NODE_IP%:%NODE_PORT%/"

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Display overall system state for kafka and coffee namespaces
+kubectl get all -n kafka
+kubectl get all -n coffee
+
+# Get NodePort for coffeeshop-service
+export NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services coffee-v1-coffeeshop-service --namespace coffee)
+export NODE_IP=$(kubectl get nodes -o jsonpath='{ $.items[*].status.addresses[?(@.type=="ExternalIP")].address }')
+echo "Order coffees at http://${NODE_IP}:${NODE_PORT}/"

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 # Display overall system state for kafka and coffee namespaces
-kubectl get all -n kafka
-kubectl get all -n coffee
+kubectl get services -n kafka
+kubectl get services -n coffee
 
 # Get NodePort for coffeeshop-service
 export NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services coffee-v1-coffeeshop-service --namespace coffee)
+# Get external IP address for node (assumes single node).
 export NODE_IP=$(kubectl get nodes -o jsonpath='{ $.items[*].status.addresses[?(@.type=="ExternalIP")].address }')
-echo "Order coffees at http://${NODE_IP}:${NODE_PORT}/"
+# If there is no ExternalIP, assume localhost
+echo "Order coffees at http://${NODE_IP:-"localhost"}:${NODE_PORT}/"

--- a/uninstall.bat
+++ b/uninstall.bat
@@ -1,13 +1,19 @@
 :: Uninstall coffeeshop-demo and kafka cluster
 helm uninstall coffee-v1 -n coffee
 
+:: Delete coffee namespace
+kubectl delete ns coffee
+
+:: Uninstall Keda Helm chart
+helm uninstall keda -n keda
+
 :: Remove Keda artifacts (not sure why helm uninstall doesn't clean this up?)
 kubectl delete apiservice v1alpha1.keda.k8s.io
 kubectl delete crd scaledobjects.keda.k8s.io
 kubectl delete crd triggerauthentications.keda.k8s.io
 
-:: Delete coffee namespace
-kubectl delete ns coffee
+:: Delete keda namespace
+kubectl delete ns keda
 
 :: Delete Kafka cluster
 kubectl delete -f kafka-strimzi.yml -n kafka

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -3,13 +3,19 @@
 # Uninstall coffeeshop-demo and kafka cluster
 helm uninstall coffee-v1 -n coffee
 
+# Delete coffee namespace
+kubectl delete ns coffee
+
+# Uninstall Keda Helm chart
+helm uninstall keda -n keda
+
 # Remove Keda artifacts (not sure why helm uninstall doesn't clean this up?)
 kubectl delete apiservice v1alpha1.keda.k8s.io
 kubectl delete crd scaledobjects.keda.k8s.io
 kubectl delete crd triggerauthentications.keda.k8s.io
 
-# Delete coffee namespace
-kubectl delete ns coffee
+# Delete keda namespace
+kubectl delete ns keda
 
 # Delete Kafka cluster
 kubectl delete -f kafka-strimzi.yml -n kafka


### PR DESCRIPTION
This PR corrects the Keda operator installation so that it is installed prior to coffeeshop-chart installation, rather than as a Helm dependency.

I've placed Keda in its own namespace, rather than being installed into the same namespace as the coffeeshop, as I think it is more realistic that multiple deployments would share a single Keda instance.

This also avoids a race condition where sometimes uninstalling the chart would delete the Keda operator before the ScaledObject CR, leading to a hang.  I suspect it was an incorrect usage of Helm dependencies to try to install Keda / Strimzi anyway - though I'm still not sure what the correct way of expressing these dependencies would be.