### PR TITLE
Add loadbalancer option for exposing coffeeshop-service

### DIFF
--- a/coffeeshop-chart/templates/_helpers.tpl
+++ b/coffeeshop-chart/templates/_helpers.tpl
@@ -13,6 +13,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "baristaKafka.fullname" -}}
 {{- printf "%s-barista-kafka" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{- define "loadBalancer.fullname" -}}
+{{- printf "%s-loadbalancer" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.

--- a/coffeeshop-chart/templates/loadbalancer.yaml
+++ b/coffeeshop-chart/templates/loadbalancer.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.loadbalancer.enabled -}}
+{{- $fullName := include "loadBalancer.fullname" . -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "coffeeshopChart.labels" . | indent 4 }}
+spec:
+  type: LoadBalancer
+  selector:
+    app: coffeeshop-service
+    release: {{ .Release.Name }}
+  ports:
+  - protocol: TCP
+    port: {{ .Values.loadbalancer.port }}
+    targetPort: 8080
+{{- end }}

--- a/coffeeshop-chart/values.yaml
+++ b/coffeeshop-chart/values.yaml
@@ -35,6 +35,12 @@ kafka:
 service:
   type: NodePort
 
+# Enable a load balancer for accessing the coffeeshop service.
+loadbalancer:
+  enabled: false
+  port: 55555
+
+# TODO: figure out how this works
 ingress:
   enabled: false
   annotations: {}


### PR DESCRIPTION
I experimented with GKE on Google Cloud, and found that it does not automatically allow NodePorts through the firewall - you must define a firewall rule yourself using the `gcloud` cli.

However, you can set up a k8s Load Balancer which does get automatically allowed through.  This PR adds a load balancer option to the Helm chart.

The load balancer works in GKE and seems to work fine on my local (docker-desktop) cluster too, though it is slightly superfluous.  Note that it doesn't work on the IKS free tier because IKS only supports load balancers for clusters with multiple nodes (and the free tier only has 1).