### PR TITLE
Wait for Keda apiservice before continuing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ script:
     # Install Keda Helm chart
   - helm repo add kedacore https://kedacore.github.io/charts
   - helm install keda kedacore/keda -n keda --wait --timeout 300s
+    # Wait for Keda apiservice to be ready
+  - kubectl wait --for=condition=Available --timeout=60s apiservices/v1beta1.external.metrics.k8s.io 
     # Deploy to local cluster via helm, into coffee namespace.
   - kubectl create ns coffee
   - helm install coffee-v1 ./coffeeshop-chart -n coffee --wait --timeout 300s --set baristaKafka.image.repository=registry:5000/barista-kafka --set baristaHttp.image.repository=registry:5000/barista-http --set coffeeshopService.image.repository=registry:5000/coffeeshop-service

--- a/install.bat
+++ b/install.bat
@@ -17,6 +17,9 @@ kubectl create ns keda
 helm repo add kedacore https://kedacore.github.io/charts
 helm install keda kedacore/keda -n keda --wait --timeout 300s
 
+:: Wait for Keda apiservice to be ready (otherwise further Helm installs will fail)
+kubectl wait --for=condition=Available --timeout=60s apiservices/v1beta1.external.metrics.k8s.io
+
 :: Install coffeeshop-demo into coffee namespace. Requires that Kafka cluster
 :: is already created. Contains custom resources:
 :: - Strimzi: CRs for orders and queue topics (installed into kafka ns)

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,9 @@ kubectl create ns keda
 helm repo add kedacore https://kedacore.github.io/charts
 helm install keda kedacore/keda -n keda --wait --timeout 300s
 
+# Wait for Keda apiservice to be ready (otherwise further Helm installs will fail)
+kubectl wait --for=condition=Available --timeout=60s apiservices/v1beta1.external.metrics.k8s.io
+
 # Install coffeeshop-demo into coffee namespace. Requires that Kafka cluster
 # is already created. Contains custom resources:
 # - Strimzi: CRs for orders and queue topics (installed into kafka ns)

--- a/kafka-strimzi.yml
+++ b/kafka-strimzi.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: kafka
 spec:
   kafka:
-    version: 2.3.0
+    version: 2.4.0
     replicas: 1
     listeners:
       plain: {}


### PR DESCRIPTION
When installing the Keda chart, we do a `helm install --wait` but this does not wait for `apiservices/v1beta1.external.metrics.k8s.io` to be available.  This seems to take a few seconds longer.  In the meantime, if you try to install a Helm chart while an apiservice is unavailable, it fails with an error.

We can wait for this specific service to be ready with `kubectl wait`.  I'm not sure if there's a better way, this this works.

Edit: Also upgrade the version of Kafka to `2.4.0`, as the latest release of Strimzi dropped support for the version (`2.3.0`) that we were using.