### PR TITLE
Set perms for Liberty outtput dir in Dockerfiles

### DIFF
--- a/barista-http/Dockerfile
+++ b/barista-http/Dockerfile
@@ -28,6 +28,9 @@ COPY --from=build --chown=1001:0 /project/barista-http/src/main/liberty/config/s
 ENV JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Xquickstart -Xms64m -Xmn48m"
 RUN /opt/ol/wlp/bin/server start defaultServer && sleep 5 && /opt/ol/wlp/bin/server stop defaultServer && (java -Xshareclasses:name=liberty-%u,nonfatal,cacheDir=/opt/ol/wlp/output/.classCache,printStats || echo "OK")
 
+# Ensure suitable permissions to support random user id on OpenShift
+RUN chmod -R g=u /opt/ol/wlp/output
+
 EXPOSE 8082
 
 # We inherit the CMD to start the Liberty server from the open-liberty image

--- a/barista-kafka/Dockerfile
+++ b/barista-kafka/Dockerfile
@@ -29,6 +29,9 @@ COPY barista-kafka/barista-name.sh /tmp
 ENV JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Xquickstart -Xms64m -Xmn48m"
 RUN /opt/ol/wlp/bin/server start defaultServer && sleep 5 && /opt/ol/wlp/bin/server stop defaultServer && (java -Xshareclasses:name=liberty-%u,nonfatal,cacheDir=/opt/ol/wlp/output/.classCache,printStats || echo "OK")
 
+# Ensure suitable permissions to support random user id on OpenShift
+RUN chmod -R g=u /opt/ol/wlp/output
+
 EXPOSE 8090
 
 # We inherit the CMD to start Liberty from the open-liberty image.

--- a/coffeeshop-service/Dockerfile
+++ b/coffeeshop-service/Dockerfile
@@ -26,6 +26,9 @@ COPY --from=build --chown=1001:0 /project/coffeeshop-service/src/main/liberty/co
 ENV JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Xquickstart -Xms64m -Xmn48m"
 RUN /opt/ol/wlp/bin/server start defaultServer && sleep 5 && /opt/ol/wlp/bin/server stop defaultServer && (java -Xshareclasses:name=liberty-%u,nonfatal,cacheDir=/opt/ol/wlp/output/.classCache,printStats || echo "OK")
 
+# Ensure suitable permissions to support random user id on OpenShift
+RUN chmod -R g=u /opt/ol/wlp/output
+
 EXPOSE 8080
 
 # We inherit the CMD to start Liberty from the open-liberty image


### PR DESCRIPTION
This PR fixes barista-http so the app will start on OpenShift.

Containers in OpenShift run by default as a random user that belongs to the root group (gid=0).  
Our Dockerfiles start up Liberty to prime the class cache.  This creates some directories under /opt/ol/wlp/output which don't have group write permission. Therefore when running in OpenShift we see errors in the Liberty log about not being able to write to temporary directories.
This can be fixed by setting permissions for the group to match the user permissions.  I've applied this fix to all 3 Dockerfiles.

The bit i don't quite understand is why this caused a problem with reading the WAR file only for barista-http.  My theory is that Liberty needed to unpack this WAR but not the others.  But anyway, it does fix the problem.

I am still seeing errors about the classcache not being readable. This could be investigated further, but I think it's more useful to look at applying the KEDA configuration to our Appsodified version instead. 