### PR TITLE
WiP: Update image tags for test deployment

### DIFF
--- a/.ci/local-registry.sh
+++ b/.ci/local-registry.sh
@@ -3,7 +3,7 @@
 # Push locally built images to the local registry that was created
 # by local-cluster.sh
 
-images="barista-kafka barista-http coffeeshop-service"
+images="coffeshop-demo:barista-kafka coffeeshop-demo:barista-http coffeeshop-demo:coffeeshop-service"
 registry="localhost:5000"
 
 for image in $images; do

--- a/.ci/local-registry.sh
+++ b/.ci/local-registry.sh
@@ -3,7 +3,7 @@
 # Push locally built images to the local registry that was created
 # by local-cluster.sh
 
-images="coffeeshop-demo:barista-kafka coffeeshop-demo:barista-http coffeeshop-demo:coffeeshop-service"
+images="ianpartridge/coffeeshop-demo:barista-kafka ianpartridge/coffeeshop-demo:barista-http ianpartridge/coffeeshop-demo:coffeeshop-service"
 registry="localhost:5000"
 
 for image in $images; do

--- a/.ci/local-registry.sh
+++ b/.ci/local-registry.sh
@@ -3,7 +3,7 @@
 # Push locally built images to the local registry that was created
 # by local-cluster.sh
 
-images="coffeshop-demo:barista-kafka coffeeshop-demo:barista-http coffeeshop-demo:coffeeshop-service"
+images="coffeeshop-demo:barista-kafka coffeeshop-demo:barista-http coffeeshop-demo:coffeeshop-service"
 registry="localhost:5000"
 
 for image in $images; do

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
   - kubectl wait --for=condition=Available --timeout=60s apiservices/v1beta1.external.metrics.k8s.io 
     # Deploy to local cluster via helm, into coffee namespace.
   - kubectl create ns coffee
-  - helm install coffee-v1 ./coffeeshop-chart -n coffee --wait --timeout 300s --set baristaKafka.image.repository=registry:5000/barista-kafka --set baristaHttp.image.repository=registry:5000/barista-http --set coffeeshopService.image.repository=registry:5000/coffeeshop-service
+  - helm install coffee-v1 ./coffeeshop-chart -n coffee --wait --timeout 300s --set baristaKafka.image.registry=registry:5000 --set baristaHttp.image.registry=registry:5000 --set coffeeshopService.image.registry=registry:5000
     # Display overall system state for kafka and coffee namespaces
   - kubectl get all -n kafka
   - kubectl get all -n coffee

--- a/build.bat
+++ b/build.bat
@@ -1,3 +1,3 @@
-docker build -f barista-kafka\Dockerfile -t barista-kafka .
-docker build -f barista-http\Dockerfile -t barista-http .
-docker build -f coffeeshop-service\Dockerfile -t coffeeshop-service .
+docker build -f barista-kafka\Dockerfile -t ianpartridge/coffeeshop-demo:barista-kafka .
+docker build -f barista-http\Dockerfile -t ianpartridge/coffeeshop-demo:barista-http .
+docker build -f coffeeshop-service\Dockerfile -t ianpartridge/coffeeshop-demo:coffeeshop-service .

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 # Build 3 images (in parallel)
 
-docker build -f barista-kafka/Dockerfile -t coffeeshop-demo:barista-kafka . > build1.log 2>&1 &
+docker build -f barista-kafka/Dockerfile -t ianpartridge/coffeeshop-demo:barista-kafka . > build1.log 2>&1 &
 BUILD1=$!
-docker build -f barista-http/Dockerfile -t coffeeshop-demo:barista-http . > build2.log 2>&1 &
+docker build -f barista-http/Dockerfile -t ianpartridge/coffeeshop-demo:barista-http . > build2.log 2>&1 &
 BUILD2=$!
-docker build -f coffeeshop-service/Dockerfile -t coffeeshop-demo:coffeeshop-service .
+docker build -f coffeeshop-service/Dockerfile -t ianpartridge/coffeeshop-demo:coffeeshop-service .
 
 wait $BUILD1 && cat build1.log && rm build1.log
 wait $BUILD2 && cat build2.log && rm build2.log

--- a/coffeeshop-chart/templates/deployment/barista-http.yaml
+++ b/coffeeshop-chart/templates/deployment/barista-http.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: barista-http
-        image: "{{ .Values.baristaHttp.image.repository }}:{{ .Values.baristaHttp.image.version }}"
+        image: "{{ .Values.baristaHttp.image.registry }}/{{ .Values.baristaHttp.image.repository }}:{{ .Values.baristaHttp.image.version }}"
         ports:
           - containerPort: 8082
         imagePullPolicy: {{ .Values.baristaHttp.image.pullPolicy }}

--- a/coffeeshop-chart/templates/deployment/barista-kafka.yaml
+++ b/coffeeshop-chart/templates/deployment/barista-kafka.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: barista-kafka
-        image: "{{ .Values.baristaKafka.image.repository }}:{{ .Values.baristaKafka.image.version }}"
+        image: "{{ .Values.baristaKafka.image.registry }}/{{ .Values.baristaKafka.image.repository }}:{{ .Values.baristaKafka.image.version }}"
         ports:
           - containerPort: 8090
         imagePullPolicy: {{ .Values.baristaKafka.image.pullPolicy }}

--- a/coffeeshop-chart/templates/deployment/coffeeshop-service.yaml
+++ b/coffeeshop-chart/templates/deployment/coffeeshop-service.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: coffeeshop-service
-        image: "{{ .Values.coffeeshopService.image.repository }}:{{ .Values.coffeeshopService.image.version }}"
+        image: "{{ .Values.coffeeshopService.image.registry }}/{{ .Values.coffeeshopService.image.repository }}:{{ .Values.coffeeshopService.image.version }}"
         ports:
           - containerPort: 8080
         livenessProbe:

--- a/coffeeshop-chart/values.yaml
+++ b/coffeeshop-chart/values.yaml
@@ -5,6 +5,7 @@
 baristaKafka: 
   replicaCount: 1
   image:
+    registry: docker.io
     repository: ianpartridge/coffeeshop-demo
     version: barista-kafka
     pullPolicy: IfNotPresent
@@ -12,6 +13,7 @@ baristaKafka:
 baristaHttp:
   replicaCount: 1
   image:
+    registry: docker.io
     repository: ianpartridge/coffeeshop-demo
     version: barista-http
     pullPolicy: IfNotPresent
@@ -19,6 +21,7 @@ baristaHttp:
 coffeeshopService:
   replicaCount: 1
   image:
+    registry: docker.io
     repository: ianpartridge/coffeeshop-demo
     version: coffeeshop-service
     pullPolicy: IfNotPresent

--- a/coffeeshop-chart/values.yaml
+++ b/coffeeshop-chart/values.yaml
@@ -5,21 +5,21 @@
 baristaKafka: 
   replicaCount: 1
   image:
-    repository: docker.io/ianpartridge/coffeeshop-demo
+    repository: ianpartridge/coffeeshop-demo
     version: barista-kafka
     pullPolicy: IfNotPresent
 
 baristaHttp:
   replicaCount: 1
   image:
-    repository: docker.io/ianpartridge/coffeeshop-demo
+    repository: ianpartridge/coffeeshop-demo
     version: barista-http
     pullPolicy: IfNotPresent
 
 coffeeshopService:
   replicaCount: 1
   image:
-    repository: docker.io/ianpartridge/coffeeshop-demo
+    repository: ianpartridge/coffeeshop-demo
     version: coffeeshop-service
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
The CI pushes the microservice images to a local registry before deploying them to test. I've updated the images it pushes to match the images we're now building.

I also separated out the image registry into a separate value in the helm chart so it's easier to parameterise. 